### PR TITLE
Simpler exposed structs and functions with BYOZMQ

### DIFF
--- a/examples/iosnoop/main.go
+++ b/examples/iosnoop/main.go
@@ -1,0 +1,52 @@
+package main
+
+// This is a simple example that opens up an IOPub connection to a Jupyter
+// kernel and displays each message.
+
+// It relies on zeromq/goczmq, but could just as easily use pebbe/zmq4
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	juno "github.com/rgbkrk/juno"
+	zmq "github.com/zeromq/goczmq"
+)
+
+func main() {
+	var connFile = flag.String("connection-file", "", "Path to connection file")
+	flag.Parse()
+
+	if *connFile == "" {
+		fmt.Fprint(os.Stderr, "Connection file is required\n")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	connInfo, err := juno.NewConnectionInfo(*connFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to open connection file\n")
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(3)
+	}
+
+	ioConnection := connInfo.IOPubConnectionString()
+	iopub := zmq.NewSubChanneler(ioConnection, "")
+
+	defer iopub.Destroy()
+
+	// Listen for messages... forever!
+	for {
+		select {
+		case wireMessage := <-iopub.RecvChan:
+			var message juno.Message
+			err := message.ParseWireProtocol(wireMessage, connInfo)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Unable to read message %v\n", err)
+			}
+			fmt.Println(message)
+		}
+	}
+
+}

--- a/juno.go
+++ b/juno.go
@@ -12,8 +12,6 @@ import (
 	"fmt"
 	"hash"
 	"os"
-
-	zmq "github.com/zeromq/goczmq"
 )
 
 // MessageHeader is a Jupyter message header
@@ -140,63 +138,6 @@ func NewConnectionInfo(filename string) (ConnectionInfo, error) {
 	return connInfo, nil
 }
 
-// OpenConnectionFile wraps NewConnectionInfo for backwards compatiblity
-func OpenConnectionFile(filename string) (ConnectionInfo, error) {
-	return NewConnectionInfo(filename)
-}
-
-// JupyterSocket is a zmq.Socket coupled with connection information
-type JupyterSocket struct {
-	ZMQSocket *zmq.Sock
-	ConnInfo  ConnectionInfo
-}
-
-// ReadMessage reads a Jupyter Protocol Message
-func (s *JupyterSocket) ReadMessage() (Message, error) {
-	var message Message
-	wireMessage, err := s.ZMQSocket.RecvMessage()
-	if err != nil {
-		return message, fmt.Errorf("Error on receive: %v", err)
-	}
-
-	message, err = s.NewMessage(wireMessage)
-	if err != nil {
-		return message, fmt.Errorf("Error on parsing wire message: %v", err)
-	}
-	return message, nil
-}
-
-// NewMessage creates a new message from a wire message using the key from this
-// socket's connection info
-func (s *JupyterSocket) NewMessage(wireMessage [][]byte) (Message, error) {
-	var message Message
-	message.ParseWireProtocol(wireMessage, s.ConnInfo)
-	return message, nil
-}
-
-// Destroy obliterates zmq sockets
-func (s *JupyterSocket) Destroy() {
-	s.ZMQSocket.Destroy()
-}
-
-// NewIOPubSocket creates a new IOPub socket (on SUB) with the connInfo given
-// subscribe is a comma delimited list of topics to subscribe to
-func NewIOPubSocket(connInfo ConnectionInfo, subscribe string) (*JupyterSocket, error) {
-	connectionString := connInfo.IOPubConnectionString()
-
-	rawIOPubSocket, err := zmq.NewSub(connectionString, subscribe)
-	if err != nil {
-		return nil, err
-	}
-
-	iopub := &JupyterSocket{
-		ZMQSocket: rawIOPubSocket,
-		ConnInfo:  connInfo,
-	}
-
-	return iopub, nil
-}
-
 // ConnectionString forms the string for zmq libraries to connect
 func (connInfo *ConnectionInfo) ConnectionString(port int) string {
 	connectionString := fmt.Sprintf("%s://%s:%d",
@@ -207,13 +148,7 @@ func (connInfo *ConnectionInfo) ConnectionString(port int) string {
 }
 
 // IOPubConnectionString forms the connection string for the IOPub socket
+// This is simply a wrapper around ConnectionString with the IOPub port
 func (connInfo *ConnectionInfo) IOPubConnectionString() string {
 	return connInfo.ConnectionString(connInfo.IOPubPort)
-}
-
-// NewMessage creates a new message based only on the connection info
-func (connInfo *ConnectionInfo) NewMessage(wireMessage [][]byte) (Message, error) {
-	var message Message
-	err := message.ParseWireProtocol(wireMessage, *connInfo)
-	return message, err
 }

--- a/juno.go
+++ b/juno.go
@@ -117,9 +117,11 @@ func (m *Message) ParseWireProtocol(wireMessage [][]byte, key []byte) (err error
 func OpenConnectionFile(filename string) (ConnectionInfo, error) {
 	var connInfo ConnectionInfo
 	connFile, err := os.Open(filename)
+
 	if err != nil {
 		return connInfo, fmt.Errorf("Couldn't open connection file: %v", err)
 	}
+	defer connFile.Close()
 
 	jsonParser := json.NewDecoder(connFile)
 

--- a/juno.go
+++ b/juno.go
@@ -200,3 +200,10 @@ func (connInfo *ConnectionInfo) ConnectionString(port int) string {
 func (connInfo *ConnectionInfo) IOPubConnection() string {
 	return connInfo.ConnectionString(connInfo.IOPubPort)
 }
+
+// NewMessage creates a new message based on
+func (connInfo *ConnectionInfo) NewMessage(wireMessage [][]byte) (Message, error) {
+	var message Message
+	err := message.ParseWireProtocol(wireMessage, []byte(connInfo.Key))
+	return message, err
+}


### PR DESCRIPTION
This started out with me trying out goczmq (and the great `Channeler` interface), eventually realizing I wanted less surface area in this library. It should only be helpers for connection info - developers should bring their own opinionated forms of zmq+go.

Since I'm [currently the only consumer of juno](https://github.com/search?utf8=%E2%9C%93&q=%22github.com%2Frgbkrk%2Fjuno%22&type=Code&ref=searchresults), I feel pretty safe in demolishing the previous interface.

What I have done is provide at least one example so you can piece together what you need. From there, perhaps we'll create other utility functions or examples to show how to listen and work on IOPub, Shell, Heartbeat, Control, and Stdin.
