### PR TITLE
[Example] Simple IOPub -> Server Sent Events

### DIFF
--- a/examples/iopub-sse/README.md
+++ b/examples/iopub-sse/README.md
@@ -1,0 +1,46 @@
+This is an example of taking all IOPub messages and sending them as Server Sent Events over HTTP.
+
+To run this example, run a jupyter kernel and find out where that kernel's connection file is:
+
+```bash
+$ jupyter console
+Jupyter Console 4.1.0.dev
+
+[ZMQTerminalIPythonApp] Loading IPython extension: storemagic
+
+In [1]: %connect_info
+{
+  "stdin_port": 54490,
+  "ip": "127.0.0.1",
+  "control_port": 54491,
+  "hb_port": 54492,
+  "signature_scheme": "hmac-sha256",
+  "key": "44644cf2-1f06-44c1-a9dd-b087ff9c2d84",
+  "shell_port": 54488,
+  "transport": "tcp",
+  "iopub_port": 54489
+}
+
+Paste the above JSON into a file, and connect with:
+    $> ipython <app> --existing <file>
+or, if you are local, you can connect with just:
+    $> ipython <app> --existing /Users/rgbkrk/Library/Jupyter/runtime/kernel-27804.json
+or even just:
+    $> ipython <app> --existing
+if this is the most recent IPython session you have started.
+```
+
+Now run this example with your own connection file:
+
+```bash
+$ go run main.go -connection-file /Users/rgbkrk/Library/Jupyter/runtime/kernel-27804.json
+2015/09/28 11:41:56 Client added. 1 registered clients
+```
+
+After that, open index.html in the same folder, type some commands in your jupyter console and watch it go!
+
+```bash
+$ open index.html
+```
+
+<img width="1324" alt="screenshot 2015-09-28 11 43 05" src="https://cloud.githubusercontent.com/assets/836375/10142075/000dc8ca-65d6-11e5-86df-c45c04bd2cbc.png">

--- a/examples/iopub-sse/index.html
+++ b/examples/iopub-sse/index.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+  <title>IOPub -> SSE</title>
+  <script src="https://wzrd.in/standalone/jupyter-js-output-area@0.0.5"></script>
+  <script src="sidecar.js"></script>
+</head>
+<body>
+  <h1>IOPub -> SSE</h1>
+  <div id="content">
+  </div>
+  <script>
+  // Browserify renames jupyter-js-output-area as jupyterJsOutputArea
+  // Picking joust as a shorthand for
+  // Jupyter OUtput STate
+
+  var source = new EventSource('http://127.0.0.1:3000');
+  var sidecar = new SideCar(document.querySelector("#content"), document)
+
+  source.addEventListener('message', function(e) {
+    if(! e.data) {
+      return
+    }
+    var message = JSON.parse(e.data);
+    sidecar.consume(message);
+
+  }, false);
+
+  source.addEventListener('open', function(e) {
+    console.log("Opened connection");
+  }, false);
+
+  source.addEventListener('error', function(e) {
+    if (e.readyState == EventSource.CLOSED) {
+      console.log("Connection closed");
+    }
+  }, false);
+
+  </script>
+</body>
+</html>

--- a/examples/iopub-sse/main.go
+++ b/examples/iopub-sse/main.go
@@ -1,0 +1,171 @@
+package main
+
+// This is a simple example that sends IOPub data as server sent events
+// over HTTP
+
+// It relies on zeromq/goczmq, but could just as easily use pebbe/zmq4
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"log"
+	"net/http"
+
+	juno "github.com/rgbkrk/juno"
+	zmq "github.com/zeromq/goczmq"
+)
+
+// Broker distributes messages to clients
+type Broker struct {
+
+	// Events are pushed to this channel by the main events-gathering routine
+	Notifier chan []byte
+
+	// New client connections
+	newClients chan chan []byte
+
+	// Closed client connections
+	closingClients chan chan []byte
+
+	// Client connections registry
+	clients map[chan []byte]bool
+}
+
+// NewServer sets up a server relying on broker for us
+func NewServer() (broker *Broker) {
+	// Instantiate a broker
+	broker = &Broker{
+		Notifier:       make(chan []byte, 1),
+		newClients:     make(chan chan []byte),
+		closingClients: make(chan chan []byte),
+		clients:        make(map[chan []byte]bool),
+	}
+
+	// Set it running - listening and broadcasting events
+	go broker.listen()
+
+	return
+}
+
+func (broker *Broker) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+
+	// Make sure that the writer supports flushing.
+	//
+	flusher, ok := rw.(http.Flusher)
+
+	if !ok {
+		http.Error(rw, "Streaming unsupported!", http.StatusInternalServerError)
+		return
+	}
+
+	rw.Header().Set("Content-Type", "text/event-stream")
+	rw.Header().Set("Cache-Control", "no-cache")
+	rw.Header().Set("Connection", "keep-alive")
+	rw.Header().Set("Access-Control-Allow-Origin", "*")
+
+	// Each connection registers its own message channel with the Broker's connections registry
+	messageChan := make(chan []byte)
+
+	// Signal the broker that we have a new connection
+	broker.newClients <- messageChan
+
+	// Remove this client from the map of connected clients
+	// when this handler exits.
+	defer func() {
+		broker.closingClients <- messageChan
+	}()
+
+	// Listen to connection close and un-register messageChan
+	notify := rw.(http.CloseNotifier).CloseNotify()
+
+	go func() {
+		<-notify
+		broker.closingClients <- messageChan
+	}()
+
+	for {
+
+		// Write to the ResponseWriter
+		// Server Sent Events compatible
+		fmt.Fprintf(rw, "data: %s\n\n", <-messageChan)
+
+		// Flush the data immediatly instead of buffering it for later.
+		flusher.Flush()
+	}
+
+}
+
+func (broker *Broker) listen() {
+	for {
+		select {
+		case s := <-broker.newClients:
+
+			// A new client has connected.
+			// Register their message channel
+			broker.clients[s] = true
+			log.Printf("Client added. %d registered clients", len(broker.clients))
+		case s := <-broker.closingClients:
+
+			// A client has dettached and we want to
+			// stop sending them messages.
+			delete(broker.clients, s)
+			log.Printf("Removed client. %d registered clients", len(broker.clients))
+		case event := <-broker.Notifier:
+
+			// We got a new event from the outside!
+			// Send event to all connected clients
+			for clientMessageChan := range broker.clients {
+				clientMessageChan <- event
+			}
+		}
+	}
+
+}
+
+func main() {
+	var connFile = flag.String("connection-file", "", "Path to connection file")
+	flag.Parse()
+
+	if *connFile == "" {
+		fmt.Fprint(os.Stderr, "Connection file is required\n")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	connInfo, err := juno.NewConnectionInfo(*connFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to open connection file\n")
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(3)
+	}
+
+	ioConnection := connInfo.IOPubConnectionString()
+	iopub := zmq.NewSubChanneler(ioConnection, "")
+
+	defer iopub.Destroy()
+
+	broker := NewServer()
+
+	go func() {
+		for {
+			select {
+			case wireMessage := <-iopub.RecvChan:
+				var message juno.Message
+				err := message.ParseWireProtocol(wireMessage, connInfo)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Unable to read message %v\n", err)
+				}
+
+				b, err := json.Marshal(message)
+
+				broker.Notifier <- b
+			}
+		}
+	}()
+
+	log.Fatal("HTTP server error: ", http.ListenAndServe("localhost:3000", broker))
+
+}

--- a/examples/iopub-sse/sidecar.js
+++ b/examples/iopub-sse/sidecar.js
@@ -1,0 +1,57 @@
+var joust = jupyterJsOutputArea;
+var OutputModel = joust.OutputModel, OutputView = joust.OutputView;
+
+var SideCar = function Sidecar(container, document) {
+  this.document = document;
+  this.container = container;
+
+  // parentID -> OutputArea
+  this.areas = new Map();
+};
+
+SideCar.prototype.consume = function consume (message) {
+  if (! message.parent_header && ! message.parent_header.msg_id) {
+      return;
+  }
+  if (message.header &&
+        (message.header.msg_type === "status" || message.header.msg_type === "execute_input")
+      )  {
+      return;
+  }
+
+  var parentID = message.parent_header.msg_id;
+  var area = this.areas[parentID];
+
+  if(!area) {
+    // Create it
+    area = new OutputArea(this.document);
+    area.el.id = parentID; // For later bookkeeping
+    this.container.appendChild(area.el);
+
+    // Keep a running tally of output areas
+    this.areas[parentID] = area;
+  }
+
+  var consumed = area.consume(message);
+  if (consumed) {
+    area.el.scrollIntoView();
+  }
+
+  return consumed;
+
+};
+
+var OutputArea = function OutputArea(document) {
+  this.model = new OutputModel();
+  this.view = new OutputView(this.model, document);
+
+  this.el = this.view.el;
+
+  this.el.className = 'output-area';
+};
+
+OutputArea.prototype.consume = function consume(message) {
+  return this.model.consumeMessage(message);
+};
+
+window.SideCar = SideCar;


### PR DESCRIPTION
This adds a simple example of taking all IOPub messages and sending them as Server Sent Events over HTTP.

To run this example, run a jupyter kernel and find out where that kernel's connection file is:

```
$ jupyter console
Jupyter Console 4.1.0.dev

[ZMQTerminalIPythonApp] Loading IPython extension: storemagic

In [1]: %connect_info
{
  "stdin_port": 54490,
  "ip": "127.0.0.1",
  "control_port": 54491,
  "hb_port": 54492,
  "signature_scheme": "hmac-sha256",
  "key": "44644cf2-1f06-44c1-a9dd-b087ff9c2d84",
  "shell_port": 54488,
  "transport": "tcp",
  "iopub_port": 54489
}

Paste the above JSON into a file, and connect with:
    $> ipython <app> --existing <file>
or, if you are local, you can connect with just:
    $> ipython <app> --existing /Users/rgbkrk/Library/Jupyter/runtime/kernel-27804.json
or even just:
    $> ipython <app> --existing
if this is the most recent IPython session you have started.
```

Now run this example with your own connection file:

```
$ go run main.go -connection-file /Users/rgbkrk/Library/Jupyter/runtime/kernel-27804.json
2015/09/28 11:41:56 Client added. 1 registered clients
```

After that, open index.html in the same folder, type some commands in your jupyter console and watch it go!

```
open index.html
```

<img width="1324" alt="screenshot 2015-09-28 11 43 05" src="https://cloud.githubusercontent.com/assets/836375/10142075/000dc8ca-65d6-11e5-86df-c45c04bd2cbc.png">
